### PR TITLE
Updating this jdbi-sample to use POJO classes with out breaking their universal POJO definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ logs
 *.ipr
 *.iws
 *.db
+/bin/

--- a/src/main/java/com/example/core/Person.java
+++ b/src/main/java/com/example/core/Person.java
@@ -14,7 +14,17 @@ public class Person {
     @JsonProperty
     private String name;
 
-    public Integer getId() {
+	public Person() {
+		super();
+	}
+
+	public Person(Integer id, String name) {
+		super();
+		this.id = id;
+		this.name = name;
+	}
+
+	public Integer getId() {
         return id;
     }
 
@@ -27,9 +37,8 @@ public class Person {
         return name;
     }
 
-    public Person setName(String name) {
+    public void setName(String name) {
         this.name = name;
-        return this;
     }
 
     @Override

--- a/src/main/java/com/example/core/mapper/PersonMapper.java
+++ b/src/main/java/com/example/core/mapper/PersonMapper.java
@@ -11,8 +11,9 @@ public class PersonMapper implements ResultSetMapper<Person>
 {
     public Person map(int index, ResultSet resultSet, StatementContext statementContext) throws SQLException
     {
-        return new Person()
-                .setId(resultSet.getInt("ID"))
-                .setName(resultSet.getString("NAME"));
+		return new Person(
+			resultSet.getInt("ID"), 
+			resultSet.getString("NAME")
+		);
     }
 }

--- a/src/test/java/com/example/core/PersonTests.java
+++ b/src/test/java/com/example/core/PersonTests.java
@@ -53,8 +53,6 @@ public class PersonTests {
     }
 
     public static Person getPerson() {
-        return new Person()
-                .setId(10)
-                .setName("person10");
+        return new Person(10, "person10");
     }
 }

--- a/src/test/java/com/example/resources/PersonResourceTests.java
+++ b/src/test/java/com/example/resources/PersonResourceTests.java
@@ -41,8 +41,8 @@ public class PersonResourceTests {
     @Test
     public void getAll() throws Exception {
         List<Person> persons = new ArrayList<>();
-        persons.add(new Person().setId(1).setName("person1"));
-        persons.add(new Person().setId(2).setName("person2"));
+        persons.add(new Person(1, "person1"));
+        persons.add(new Person(2, "person2"));
         when(personDAO.getAll()).thenReturn(persons);
 
         List<Person> result = resources.client().target("/person").request().get(new GenericType<List<Person>>() {});
@@ -54,9 +54,7 @@ public class PersonResourceTests {
     @Test
     public void get() throws Exception {
         when(personDAO.findById(1)).thenReturn(
-                new Person()
-                        .setId(1)
-                        .setName("person1")
+                new Person(1, "person1")
         );
 
         Person person = resources.client().target("/person/1").request().get(new GenericType<Person>() {});
@@ -79,7 +77,8 @@ public class PersonResourceTests {
 
     @Test
     public void update_invalid_person() throws Exception {
-        Person person = PersonTests.getPerson().setName(null);
+        Person person = PersonTests.getPerson();
+        person.setName(null);
 
         try {
             Person updatedPerson = resources.client().target("/person/10")
@@ -106,7 +105,8 @@ public class PersonResourceTests {
 
     @Test
     public void add_invalid_person() throws Exception {
-        Person newPerson = PersonTests.getPerson().setName(null);
+        Person newPerson = PersonTests.getPerson();
+        newPerson.setName(null);
 
         try {
             Person person = resources.client().target("/person")


### PR DESCRIPTION
Updating this jdbi-sample to use POJO classes with out breaking their universal POJO definition  (remove returning Object types in setters) by using a Constructor with all types. Creating a patch for a pull request. Updating the tests too. 

Please Review and Merge.
